### PR TITLE
Loose teams

### DIFF
--- a/src/README.ejs
+++ b/src/README.ejs
@@ -12,7 +12,7 @@ We're playing
 <% } else { -%>
 <p align="center">
   <b>It's the
-  <%= state.currentPlayer === "b" ? "black" : "white" %>
+  <%= state.currentPlayer === "b" ? ":black_circle:black" : ":white_circle:white" %>
   team's turn.</b>
 </p>
 
@@ -24,14 +24,14 @@ If it's not your turn, check back later, or
 [ask a friend](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+Take+your+turn+at+https://github.com/rossjrw/rossjrw+%23RoyalGameOfUr+%23github)
 to make a move.
 * If you've not yet played a turn this game, make a move now to join the
-<%= state.currentPlayer === "b" ? "black" : "white" %>
+<%= state.currentPlayer === "b" ? ":black_circle:black" : ":white_circle:white" %>
 team.
 <% } -%>
 
 <p align="center"><img src="https://raw.githubusercontent.com/rossjrw/ur/play/games/current/board.<%= context.issue.number %>.svg"></p>
 
 <% if (state.currentPlayer) { -%>
-  **<%= state.currentPlayer === "b" ? "Black" : "White" %> team:**
+  **<%= state.currentPlayer === "b" ? ":black_circle:Black" : ":white_circle:White" %> team:**
   You rolled a <%= state.diceResult %>!
 <% } -%>
 What would you like to do?
@@ -62,28 +62,31 @@ What would you like to do?
 
 <details><summary>How do I play?</summary>
 
+  It's the :white_circle:white team versus the :black_circle:black team.
+
   The turn starts by rolling 4 binary dice, which
   results in a number from 0 to 4. The current team gets to move one of their
   pieces by that many tiles.
 
   All of your pieces start on position 0 (the space just before tile 1). Your
   goal is to get all seven of them off the board by moving them onto position
-  15 (the space just after tile 14). This is called "**ascending**" a piece.
-  You also want to prevent your opponent from ascending their pieces.
+  15 (the space just after tile 14). This is called **:rocket:ascending** a
+  piece. You also want to prevent your opponent from :rocket:ascending their
+  pieces.
 
   You will move your pieces along the tiles from tile 1 to tile 14. The tiles
   on your side of the board (tiles 1 through 4, 13, and 14) are safe — only
   your pieces can be there. However, the tiles in the middle (tiles 5 through
   12) are unsafe — your opponent's pieces can also be here. If one team's piece
   lands on the same tile as another team's piece, the piece that was landed on
-  is **captured**! It goes all the way back to position 0.
+  is **:crossed_swords:captured**! It goes all the way back to position 0.
 
-  If you land on a **rosette** (tiles 4, 8, and 14), your team gets to take
-  another turn. Also, a piece that is on the rosette on tile 8 *cannot be
-  captured*.
+  If you land on a **:rosette:rosette** (tiles 4, 8, and 14), your team gets to
+  take another turn. Also, a piece that is on the :rosette:rosette on tile 8
+  *cannot be :crossed_swords:captured*.
 
-  The first team to **ascend** all seven of their pieces — that is, move them
-  off the board onto position 15 — wins!
+  The first team to **:rocket:ascend** all seven of their pieces — that is,
+  move them off the board onto position 15 — :crown:wins!
 
   Watch [Tom Scott play against Irving
   Finkel](https://www.youtube.com/watch?v=WZskjLq040I) in 2017.
@@ -106,9 +109,9 @@ What would you like to do?
   do is click Submit.
 
   It will take a moment for Github Actions to acknowledge your move, but once
-  it does, you'll see it react with the 'eyes' emoji. No more than a minute
-  later it should react with the 'rocket' emoji to let you know that your move
-  was successful.
+  it does, you'll see it react with the 'eyes' emoji (:eyes:). No more than a
+  minute later it should react with the 'rocket' emoji (:rocket:) to let you
+  know that your move was successful.
 
   If you don't see any of that, then something went wrong. Ping me in your
   issue by typing `cc @rossjrw`, and I'll take a look.

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -36,6 +36,12 @@ What would you like to do?
 
 <details><summary>The game so far</summary>
 
+## Players & move count
+
+<%- teamTable %>
+
+## Event log
+
 | Time | Turn | Event | Issue | Board |
 | :---: | :---: | :--- | :---: | :---: |
 <% logItems.forEach((logItem, index) => { -%>

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -1,3 +1,6 @@
+<img align="right" src="https://github.com/rossjrw/rossjrw/workflows/build/badge.svg?branch=source"/>
+<img align="right" src="https://github.com/rossjrw/rossjrw/workflows/play/badge.svg?branch=play"/>
+
 Welcome to my Github profile!
 We're playing
 [The Royal Game of Ur](https://en.wikipedia.org/wiki/Royal_Game_of_Ur).

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -6,22 +6,27 @@ We're playing
 [The Royal Game of Ur](https://en.wikipedia.org/wiki/Royal_Game_of_Ur).
 <%= state.currentPlayer ? "**This game is in progress,** but you can join!" : "**This game has ended!**" %>
 
-You're on a team! :wave:
-If your GitHub username starts with a letter in the first half of the alphabet
-(A–M), you're on the **black** team.
-Otherwise, you're on the **white** team.
-<% if (state.currentPlayer === "b") { -%>
-  **It's black to play.**
-<% } else if (state.currentPlayer === "w") { -%>
-  **It's white to play.**
-<% } else { -%>
+<% if (state.currentPlayer === undefined) { -%>
   This game has finished, so we're just waiting for someone to click _"Start a
   new game"._ That could be you!
-<% } -%>
+<% } else { -%>
+<p align="center">
+  <b>It's the
+  <%= state.currentPlayer === "b" ? "black" : "white" %>
+  team's turn.</b>
+</p>
 
+You're on a team! :wave:
+
+* If you've already played a turn this game, you know which team you're on!
+(_you can't change it!_)
 If it's not your turn, check back later, or
-[poke a friend](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+Take+your+turn+at+https://github.com/rossjrw+%23ur+%23github)
-to make a move!
+[ask a friend](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+Take+your+turn+at+https://github.com/rossjrw/rossjrw+%23RoyalGameOfUr+%23github)
+to make a move.
+* If you've not yet played a turn this game, make a move now to join the
+<%= state.currentPlayer === "b" ? "black" : "white" %>
+team.
+<% } -%>
 
 <p align="center"><img src="https://raw.githubusercontent.com/rossjrw/ur/play/games/current/board.<%= context.issue.number %>.svg"></p>
 
@@ -39,16 +44,16 @@ What would you like to do?
 
 <details><summary>The game so far</summary>
 
-## Players & move count
+## Who's on each team?
 
 <%- teamTable %>
 
-## Event log
+## What's happened so far?
 
 | Time | Turn | Event | Issue | Board |
 | :---: | :---: | :--- | :---: | :---: |
-<% logItems.forEach((logItem, index) => { -%>
-  | <%= logItem[0] %> | **<%= index %>** | <%= logItem[1] %> | <%= logItem[2] %> | <%= logItem[3] %> |
+<% logItems.slice().reverse().forEach((logItem, index) => { -%>
+  | <%= logItem[0] %> | **<%= logItems.length - index %>** | <%= logItem[1] %> | <%= logItem[2] %> | <%= logItem[3] %> |
 <% }) -%>
 
 </details>

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -72,9 +72,9 @@ What would you like to do?
   You also want to prevent your opponent from ascending their pieces.
 
   You will move your pieces along the tiles from tile 1 to tile 14. The tiles
-  on your side of the board (tiles 1 through 4, 13, and 14) are safe — only your
-  pieces can be there. However, the tiles in the middle (tiles 5 through 12)
-  are unsafe — your opponent's pieces can also be here. If one team's piece
+  on your side of the board (tiles 1 through 4, 13, and 14) are safe — only
+  your pieces can be there. However, the tiles in the middle (tiles 5 through
+  12) are unsafe — your opponent's pieces can also be here. If one team's piece
   lands on the same tile as another team's piece, the piece that was landed on
   is **captured**! It goes all the way back to position 0.
 
@@ -93,10 +93,12 @@ What would you like to do?
   Playing Ur on my GitHub profile is easy. The dice have already been rolled
   for you — all you have to do is decide what to do with them.
 
-  Your team is determined by your username. If it starts with a letter in the
-  first half of the English alphabet (A–M), you're on the black team;
-  otherwise, you're on the white team. You can't play a move when it's the
-  other team's turn, though you can certainly try.
+  Anyone can join either team at any time, but once you're in a team, you're
+  locked into it until the game ends. You can't play a move when it's the
+  other team's turn.
+
+  _([Before 2020-09-19](https://github.com/rossjrw/rossjrw/pull/133), your team
+  was determined by your username. This is no longer the case.)_
 
   There will be a list of links below the board image with each possible move.
   Clicking one of those will take you to a page where you can create an Issue

--- a/src/error.ts
+++ b/src/error.ts
@@ -59,9 +59,11 @@ export function handleError(
     state: "closed",
   })
 
-  core.error(error)
-
-  // Seems like this is the only reliable way for me to know what actually
-  // caused the error
-  throw error
+  // Only raise an error if there was an actual uncaught problem
+  if (error.message in ERROR_DESC) {
+    core.error(error) 
+    // Seems like this is the only reliable way for me to know what actually
+    // caused the error
+    throw error
+  }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -37,7 +37,7 @@ export function handleError(
     NON_NUMERIC_ID: "You've told me what move to make, but the game ID you've given me isn't a number.",
     // Execution errors
     MOVE_WHEN_GAME_ENDED: "You can't make a move when the game has finished! You'll have to start a new game instead.",
-    WRONG_TEAM: `Sorry, you're on the ${teamName(playerTeam)} team, but it's ${teamName(getOppositeTeam(playerTeam))} to play. You'll have to wait until it's the ${playerTeam} team's turn before you can make a move.`,
+    WRONG_TEAM: `Sorry, you're on the ${teamName(playerTeam)} team, but it's ${teamName(getOppositeTeam(playerTeam))} to play. You'll have to wait until it's the ${teamName(playerTeam)} team's turn before you can make a move.`,
     WRONG_DICE_COUNT: "You tried to move a piece by the wrong number of places. Check the dice roll!",
     NO_MOVE_POSITION: "I can't tell which piece you want to move.",
     IMPOSSIBLE_MOVE: "Woah, that's not a legal move! Maybe someone snuck in a move before yours.",

--- a/src/error.ts
+++ b/src/error.ts
@@ -5,6 +5,8 @@ import { get } from "lodash"
 
 import { addReaction, addLabels } from '@/issues'
 import { getPlayerTeam } from '@/player'
+import { teamName, getOppositeTeam } from '@/teams'
+import { Log } from '@/log'
 
 interface ErrorDescriptions {
   [error_type: string]: string
@@ -12,6 +14,7 @@ interface ErrorDescriptions {
 
 export function handleError(
   error: Error,
+  log: Log,
   octokit: Octokit,
   context: Context,
   core: typeof _core,
@@ -22,6 +25,8 @@ export function handleError(
    *
    * @param error: The error to report with an ID matching the desc object.
    */
+  const playerTeam = getPlayerTeam(context.actor, log)
+
   const ERROR_DESC: ErrorDescriptions = {
     // Action parsing
     WRONG_GAME: "Sorry, I only know how to play Ur.",
@@ -32,7 +37,7 @@ export function handleError(
     NON_NUMERIC_ID: "You've told me what move to make, but the game ID you've given me isn't a number.",
     // Execution errors
     MOVE_WHEN_GAME_ENDED: "You can't make a move when the game has finished! You'll have to start a new game instead.",
-    WRONG_TEAM: `Sorry, you're on the ${getPlayerTeam(context.actor) === "b" ? "black" : "white"} team — you can't make moves for the ${getPlayerTeam(context.actor) === "b" ? "white" : "black"} team!`,
+    WRONG_TEAM: `Sorry, you're on the ${teamName(playerTeam)} team, but it's ${teamName(getOppositeTeam(playerTeam))} to play. You'll have to wait until it's the ${playerTeam} team's turn before you can make a move.`,
     WRONG_DICE_COUNT: "You tried to move a piece by the wrong number of places. Check the dice roll!",
     NO_MOVE_POSITION: "I can't tell which piece you want to move.",
     IMPOSSIBLE_MOVE: "Woah, that's not a legal move! Maybe someone snuck in a move before yours.",

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -7,6 +7,7 @@ import { analyseMove } from '@/analyseMove'
 import { updateSvg } from '@/updateSvg'
 import { Change } from '@/play'
 import { Log } from './log'
+import {makeTeamListTable} from './teams'
 
 export async function generateReadme (
   state: Ur.State,
@@ -90,7 +91,12 @@ export async function generateReadme (
     ]
   })
 
-  const readme = ejs.render(template, { actions, state, logItems, context })
+  const teamTable = makeTeamListTable(log, true)
+
+  const readme = ejs.render(
+    template,
+    { actions, state, logItems, context, teamTable }
+  )
 
   const currentReadmeFile = await octokit.repos.getContents({
     owner: context.repo.owner,

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -6,8 +6,8 @@ import ejs from "ejs"
 import { analyseMove } from '@/analyseMove'
 import { updateSvg } from '@/updateSvg'
 import { Change } from '@/play'
-import { Log } from './log'
-import {makeTeamListTable} from './teams'
+import { Log } from '@/log'
+import { makeTeamListTable } from '@/teams'
 
 export async function generateReadme (
   state: Ur.State,

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -7,7 +7,7 @@ import { analyseMove } from '@/analyseMove'
 import { updateSvg } from '@/updateSvg'
 import { Change } from '@/play'
 import { Log } from '@/log'
-import { makeTeamListTable } from '@/teams'
+import { makeTeamListTable, teamName } from '@/teams'
 
 export async function generateReadme (
   state: Ur.State,
@@ -85,7 +85,7 @@ export async function generateReadme (
   const logItems = log.internalLog.map(logItem => {
     return [
       `${logItem.time.split(".")[0].split("T").join(" ")}`,
-      `${logItem.team === Ur.BLACK ? ":black_circle:" : ":white_circle:"} ${logItem.action === "pass" ? "" : `**[@${logItem.username}](https://github.com/${logItem.username})**`} ${logItem.message}`,
+      `:${teamName(logItem.team)}_circle: ${logItem.action === "pass" ? "" : `**[@${logItem.username}](https://github.com/${logItem.username})**`} ${logItem.message}`,
       `[#${logItem.issue}](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${logItem.issue})`,
       `${logItem.boardImage === null ? "" : `[link](${logItem.boardImage})`}`,
     ]

--- a/src/move.ts
+++ b/src/move.ts
@@ -117,7 +117,7 @@ export async function makeMove (
     // Update the log with this action
     log.addToLog(
       "move",
-      `${events.ascensionHappened ? "ascended" : "moved"} a ${state.currentPlayer === Ur.BLACK ? "black" : "white"} piece ${fromPosition === 0 ? "onto the board" : `from position ${fromPosition}`} ${events.ascensionHappened ? ":rocket:" : `to position ${toPosition}${events.captureHappened ? ` — captured a ${state.currentPlayer === Ur.BLACK ? "white" : "black"} piece :crossed_swords:` : ""}`}${events.rosetteClaimed ? " — claimed a rosette :rosette:" : ""}${events.gameWon ? " — won the game :crown:" : ""}`,
+      `${events.ascensionHappened ? "ascended" : "moved"} a ${teamName(state.currentPlayer)} piece ${fromPosition === 0 ? "onto the board" : `from position ${fromPosition}`} ${events.ascensionHappened ? ":rocket:" : `to position ${toPosition}${events.captureHappened ? ` — captured a ${teamName(getOppositeTeam(state.currentPlayer))} piece :crossed_swords:` : ""}`}${events.rosetteClaimed ? " — claimed a rosette :rosette:" : ""}${events.gameWon ? " — won the game :crown:" : ""}`,
       state.currentPlayer,
     )
 
@@ -137,7 +137,7 @@ export async function makeMove (
     // If a 0 was rolled, then the new turn should be passed
     log.addToLog(
       "pass",
-      `The ${newState.currentPlayer === Ur.BLACK ? "black" : "white"} team rolled a ${newState.diceResult} and their turn was automatically passed`,
+      `The ${teamName(newState.currentPlayer)} team rolled a ${newState.diceResult} and their turn was automatically passed`,
       newState.currentPlayer!,
     )
     changes = changes.concat(

--- a/src/move.ts
+++ b/src/move.ts
@@ -3,13 +3,14 @@ import { Context } from "@actions/github/lib/context"
 import Ur from "ur-game"
 import { isEmpty } from "lodash"
 
-import { playerIsOnTeam } from '@/player'
+import { playerIsOnTeam, getPlayerTeam } from '@/player'
 import { addLabels } from '@/issues'
 import { analyseMove } from '@/analyseMove'
 import { generateReadme } from '@/generateReadme'
 import { Change } from '@/play'
 import { Log } from '@/log'
 import { makeVictoryMessage } from '@/victory'
+import { getOppositeTeam, teamName } from '@/teams'
 
 export async function makeMove (
   state: Ur.State,
@@ -43,8 +44,16 @@ export async function makeMove (
     // be possible for a player to pass
     newState = Ur.voidTurn(state, state.currentPlayer)
   } else {
+    // Store the player's current team before anything else
+    const playerTeam = getPlayerTeam(context.actor, log)
     // First I need to validate which team the user is on
-    if (!playerIsOnTeam(context.actor, state.currentPlayer, log)) {
+    if (
+      playerIsOnTeam(
+        context.actor,
+        getOppositeTeam(state.currentPlayer)!,
+        log
+      )
+    ) {
       throw new Error('WRONG_TEAM')
     }
     if (state.currentPlayer === Ur.BLACK) {
@@ -96,7 +105,7 @@ export async function makeMove (
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: context.issue.number,
-      body: `@${context.actor} Done! You ${events.ascensionHappened ? "ascended" : "moved"} a ${state.currentPlayer === Ur.BLACK ? "black" : "white"} piece ${fromPosition === 0 ? "onto the board" : `from position ${fromPosition}`}${events.ascensionHappened ? ". " : ` to position ${toPosition}${events.captureHappened ? ", capturing the opponents' piece! " : ". "}`}${events.rosetteClaimed ? "You claimed a rosette, meaning that your team gets to take another turn! " : ""}${events.gameWon ? "This was the winning move! " : ""}\n\nAsk a friend to ${events.gameWon ? "start the next game" : "make the next move"}: [share on Twitter](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+I+just+${events.gameWon ? "won+a+game" : "moved"}+%E2%80%94+${events.gameWon ? "start+the+next+one" : "take+your+turn" }+at+https://github.com/rossjrw+%23ur+%23github)`
+      body: `@${context.actor} Done! You ${events.ascensionHappened ? "ascended" : "moved"} a ${teamName(state.currentPlayer)} piece ${fromPosition === 0 ? "onto the board" : `from position ${fromPosition}`}${events.ascensionHappened ? ". " : ` to position ${toPosition}${events.captureHappened ? ", capturing the opponents' piece! " : ". "}`}${events.rosetteClaimed ? "You claimed a rosette, meaning that your team gets to take another turn! " : ""}${events.gameWon ? "This was the winning move! " : ""}\n\n${playerTeam === undefined ? `You've joined the ${teamName(state.currentPlayer)} team! This will be your team until this game ends.` : `The ${teamName(state.currentPlayer)} team thanks you for your continued participation!`}\n\nAsk a friend to ${events.gameWon ? "start the next game" : "make the next move"}: [share on Twitter](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+I+just+${events.gameWon ? "won+a+game" : "moved"}+%E2%80%94+${events.gameWon ? "start+the+next+one" : "take+your+turn" }+at+https://github.com/rossjrw/rossjrw+%23RoyalGameOfUr+%23github)`
     })
     octokit.issues.update({
       owner: context.repo.owner,

--- a/src/move.ts
+++ b/src/move.ts
@@ -44,7 +44,7 @@ export async function makeMove (
     newState = Ur.voidTurn(state, state.currentPlayer)
   } else {
     // First I need to validate which team the user is on
-    if (!playerIsOnTeam(context.actor, state.currentPlayer)) {
+    if (!playerIsOnTeam(context.actor, state.currentPlayer, log)) {
       throw new Error('WRONG_TEAM')
     }
     if (state.currentPlayer === Ur.BLACK) {

--- a/src/new.ts
+++ b/src/new.ts
@@ -75,7 +75,7 @@ export async function resetGame (
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: context.issue.number,
-    body: `@${context.actor} Done! You started a new game.\n\nIt's ${teamName(newState.currentPlayer)} to play! [Make the first move yourself](https://github.com/rossjrw/rossjrw), or ask a friend: [share on Twitter](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+I+just++started+a+new+game+%E2%80%94+take+the+first+turn+at+https://github.com/rossjrw+%23ur+%23github)`
+    body: `@${context.actor} Done! You started a new game.\n\nIt's ${teamName(newState.currentPlayer)} to play! [Make the first move yourself](https://github.com/rossjrw/rossjrw), or ask a friend: [share on Twitter](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+I+just+started+a+new+game+%E2%80%94+take+the+first+turn+at+https://github.com/rossjrw+%23ur+%23github)`
   })
   octokit.issues.update({
     owner: context.repo.owner,

--- a/src/new.ts
+++ b/src/new.ts
@@ -6,6 +6,7 @@ import { getPlayerTeam } from '@/player'
 import { generateReadme } from '@/generateReadme'
 import { Change } from '@/play'
 import { Log } from '@/log'
+import { teamName } from '@/teams'
 
 export async function resetGame (
   gamePath: string,
@@ -41,6 +42,7 @@ export async function resetGame (
   const startingPlayerTeam = getPlayerTeam(context.actor, log)
   let gameStartTeam: Ur.Player
   if (startingPlayerTeam === undefined) {
+    // If the team is null, which it should be, white plays first
     gameStartTeam = Ur.WHITE
   } else {
     gameStartTeam = startingPlayerTeam
@@ -73,7 +75,7 @@ export async function resetGame (
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: context.issue.number,
-    body: `@${context.actor} Done! You started a new game.\n\nMake the next move yourself, or ask a friend: [share on Twitter](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+A+new+game+just+started+%E2%80%94+take+your+turn+at+https://github.com/rossjrw+%23ur+%23github)`
+    body: `@${context.actor} Done! You started a new game.\n\nIt's ${teamName(newState.currentPlayer)} to play! [Make the first move yourself](https://github.com/rossjrw/rossjrw), or ask a friend: [share on Twitter](https://twitter.com/share?text=I'm+playing+The+Royal+Game+of+Ur+on+a+GitHub+profile.+I+just++started+a+new+game+%E2%80%94+take+the+first+turn+at+https://github.com/rossjrw+%23ur+%23github)`
   })
   octokit.issues.update({
     owner: context.repo.owner,

--- a/src/new.ts
+++ b/src/new.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/rest"
 import { Context } from "@actions/github/lib/context"
 import Ur from "ur-game"
+import { sample } from 'lodash'
 
 import { getPlayerTeam } from '@/player'
 import { generateReadme } from '@/generateReadme'
@@ -35,7 +36,17 @@ export async function resetGame (
   // because the old file is about to be overwritten with a new log
 
   // Make a new game state
-  const newState = Ur.startGame(7, 4, getPlayerTeam(context.actor))
+  // The starting team should be the same team as the initiating player, so
+  // that they can immediately play, but as of rossjrw/rossjrw#133 that team
+  // should always be null
+  const startingPlayerTeam = getPlayerTeam(context.actor)
+  let gameStartTeam: Ur.Player
+  if (startingPlayerTeam === null) {
+    gameStartTeam = Ur.WHITE
+  } else {
+    gameStartTeam = startingPlayerTeam
+  }
+  const newState = Ur.startGame(7, 4, gameStartTeam)
 
   // Save the new state
   changes.push({

--- a/src/new.ts
+++ b/src/new.ts
@@ -1,7 +1,6 @@
 import { Octokit } from "@octokit/rest"
 import { Context } from "@actions/github/lib/context"
 import Ur from "ur-game"
-import { sample } from 'lodash'
 
 import { getPlayerTeam } from '@/player'
 import { generateReadme } from '@/generateReadme'
@@ -39,9 +38,9 @@ export async function resetGame (
   // The starting team should be the same team as the initiating player, so
   // that they can immediately play, but as of rossjrw/rossjrw#133 that team
   // should always be null
-  const startingPlayerTeam = getPlayerTeam(context.actor)
+  const startingPlayerTeam = getPlayerTeam(context.actor, log)
   let gameStartTeam: Ur.Player
-  if (startingPlayerTeam === null) {
+  if (startingPlayerTeam === undefined) {
     gameStartTeam = Ur.WHITE
   } else {
     gameStartTeam = startingPlayerTeam

--- a/src/play.ts
+++ b/src/play.ts
@@ -91,7 +91,7 @@ export default async function play (
     addReaction("rocket", octokit, context)
   } catch (error) {
     // If there was an error, forward it to the user, then stop
-    handleError(error, octokit, context, core)
+    handleError(error, log, octokit, context, core)
     return
   }
 }

--- a/src/play.ts
+++ b/src/play.ts
@@ -1,7 +1,6 @@
 import { Octokit } from "@octokit/rest/index"
 import { Context } from "@actions/github/lib/context"
 import { default as _core } from "@actions/core"
-import Ur from "ur-game"
 
 import { addReaction } from '@/issues'
 import { handleError } from '@/error'
@@ -10,6 +9,7 @@ import { makeMove } from '@/move'
 import { makeCommit } from '@/commit'
 import { Log } from '@/log'
 import { getFile } from '@/getFile'
+import { teamName } from '@/teams'
 
 export interface Change {
   path: string
@@ -82,7 +82,7 @@ export default async function play (
 
     // All the changes have been collected - commit them
     await makeCommit(
-      `@${context.actor} ${command === "new" ? "Start a new game" : `Move ${state.currentPlayer === Ur.BLACK ? "black" : "white"} ${move}`} (#${context.issue.number})`,
+      `@${context.actor} ${command === "new" ? "Start a new game" : `Move ${teamName(state.currentPlayer)} ${move}`} (#${context.issue.number})`,
       changes,
       octokit,
       context,

--- a/src/player.ts
+++ b/src/player.ts
@@ -11,8 +11,15 @@ export function playerIsOnTeam (
    * @param team: The team to check against.
    */
   if (username === "rossjrw") {
+    // Nobody tells me what to do except me
     return true
   }
+  const playerTeam = getPlayerTeam(username)
+  if (playerTeam === null) {
+    // A player who hasn't played yet is allowed on either team
+    return true
+  }
+  // Otherwise, players are locked into existing teams
   return getPlayerTeam(username) === team
 }
 
@@ -20,7 +27,8 @@ export function getPlayerTeam (
   username: string,
 ): Ur.Player {
   /**
-   * Assigns a player to a team based on their username.
+   * Checks what team a player is on. Returns null if that team has not yet
+   * been defined.
    */
   if (/^[A-M]/i.test(username)) {
     return Ur.BLACK

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,8 +1,11 @@
 import Ur from "ur-game"
 
+import { Log } from '@/log'
+
 export function playerIsOnTeam (
   username: string,
   team: Ur.Player,
+  log: Log,
 ): boolean {
   /**
    * Checks if a player is on the given team.
@@ -14,25 +17,31 @@ export function playerIsOnTeam (
     // Nobody tells me what to do except me
     return true
   }
-  const playerTeam = getPlayerTeam(username)
-  if (playerTeam === null) {
+  const playerTeam = getPlayerTeam(username, log)
+  if (playerTeam === undefined) {
     // A player who hasn't played yet is allowed on either team
     return true
   }
   // Otherwise, players are locked into existing teams
-  return getPlayerTeam(username) === team
+  return playerTeam === team
 }
 
 export function getPlayerTeam (
   username: string,
-): Ur.Player | null {
+  log: Log,
+): Ur.Player | undefined {
   /**
-   * Checks what team a player is on. Returns null if that team has not yet
-   * been defined.
+   * Checks what team a player is on.
    */
-  if (/^[A-M]/i.test(username)) {
-    return Ur.BLACK
-  } else {
-    return Ur.WHITE
-  }
+  return log.internalLog.find(item => item.username === username)?.team
+}
+
+export function getPlayerTeamSource (
+  username: string,
+  log: Log,
+): number | undefined {
+  /**
+   * Returns the issue number that determined a player's team for this game.
+   */
+  return log.internalLog.find(item => item.username === username)?.issue
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -25,7 +25,7 @@ export function playerIsOnTeam (
 
 export function getPlayerTeam (
   username: string,
-): Ur.Player {
+): Ur.Player | null {
   /**
    * Checks what team a player is on. Returns null if that team has not yet
    * been defined.

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,7 +1,7 @@
 import Ur from "ur-game"
 
 export function teamName (
-  team: Ur.Player
+  team: Ur.Player | undefined
 ): string {
   if (team === Ur.BLACK) {
     return "black"
@@ -9,17 +9,17 @@ export function teamName (
   if (team === Ur.WHITE) {
     return "white"
   }
-  throw new Error('UNKNOWN_TEAM')
+  return "unknown"
 }
 
 export function getOppositeTeam (
-  team: Ur.Player
-): Ur.Player {
+  team: Ur.Player | undefined
+): Ur.Player | undefined {
   if (team === Ur.BLACK) {
     return Ur.WHITE
   }
   if (team === Ur.WHITE) {
     return Ur.BLACK
   }
-  throw new Error('UNKNOWN_TEAM')
+  return undefined
 }

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -35,9 +35,13 @@ export function getOppositeTeam (
 
 export function makeTeamListTable (
   log: Log,
+  hasPlayerLinks: boolean,
 ): string {
   /**
    * Makes a table containing team members.
+   *
+   * @param hasPlayerLinks: Players as hyperlinks? Required for README, but not
+   * required for issues.
    */
   const PLAYERS_TABLE = `<table>
     <thead>
@@ -57,8 +61,8 @@ export function makeTeamListTable (
 
   const players = makeTeamStats(log)
 
-  const blackPlayers = makeTeamListColumn(players, Ur.BLACK)
-  const whitePlayers = makeTeamListColumn(players, Ur.WHITE)
+  const blackPlayers = makeTeamListColumn(players, Ur.BLACK, hasPlayerLinks)
+  const whitePlayers = makeTeamListColumn(players, Ur.WHITE, hasPlayerLinks)
 
   return ejs.render(PLAYERS_TABLE, { blackPlayers, whitePlayers })
 }
@@ -90,6 +94,7 @@ export function makeTeamStats (
 function makeTeamListColumn (
   players: TeamPlayer[],
   team: Ur.Player,
+  hasLinks: boolean,
 ): string[] {
   return players.filter(player => {
     return player.team === team
@@ -98,6 +103,10 @@ function makeTeamListColumn (
     if (a.moves < b.moves) return 1
     return 0
   }).map(player => {
-    return `@${player.name} (${player.moves})`
+    if (hasLinks) {
+      return `**[@${player.name}](https://github.com/${player.name})** (${player.moves})`
+    } else {
+      return `@${player.name} (${player.moves})`
+    }
   })
 }

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -45,7 +45,7 @@ export function makeTeamListTable (
    */
   const PLAYERS_TABLE = `<table>
     <thead>
-      <tr><th colspan=2>Players this game</th></tr>
+      <tr><th colspan=2>Players in this game</th></tr>
     </thead>
     <tbody>
       <tr>

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,0 +1,25 @@
+import Ur from "ur-game"
+
+export function teamName (
+  team: Ur.Player
+): string {
+  if (team === Ur.BLACK) {
+    return "black"
+  }
+  if (team === Ur.WHITE) {
+    return "white"
+  }
+  throw new Error('UNKNOWN_TEAM')
+}
+
+export function getOppositeTeam (
+  team: Ur.Player
+): Ur.Player {
+  if (team === Ur.BLACK) {
+    return Ur.WHITE
+  }
+  if (team === Ur.WHITE) {
+    return Ur.BLACK
+  }
+  throw new Error('UNKNOWN_TEAM')
+}

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,4 +1,13 @@
 import Ur from "ur-game"
+import ejs from "ejs"
+
+import { Log } from '@/log'
+
+interface TeamPlayer {
+  name: string
+  team: Ur.Player
+  moves: number
+}
 
 export function teamName (
   team: Ur.Player | undefined
@@ -22,4 +31,73 @@ export function getOppositeTeam (
     return Ur.BLACK
   }
   return undefined
+}
+
+export function makeTeamListTable (
+  log: Log,
+): string {
+  /**
+   * Makes a table containing team members.
+   */
+  const PLAYERS_TABLE = `<table>
+    <thead>
+      <tr><th colspan=2>Players this game</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td align="right"><b>Black team</b> :black_circle:</td>
+        <td>:white_circle: <b> White team</b></td>
+      </tr>
+      <tr align="center">
+        <td><%- blackPlayers.join("<br>") %></td>
+        <td><%- whitePlayers.join("<br>") %></td>
+      </tr>
+    </tbody>
+  </table>`
+
+  const players = makeTeamStats(log)
+
+  const blackPlayers = makeTeamListColumn(players, Ur.BLACK)
+  const whitePlayers = makeTeamListColumn(players, Ur.WHITE)
+
+  return ejs.render(PLAYERS_TABLE, { blackPlayers, whitePlayers })
+}
+
+export function makeTeamStats (
+  log: Log,
+): TeamPlayer[] {
+
+  const players: TeamPlayer[] = []
+
+  log.internalLog.forEach(logItem => {
+    const playerIndex = players.findIndex(player => {
+      return player.name === logItem.username && player.team === logItem.team
+    })
+    if (playerIndex === -1) {
+      players.push({
+        name: logItem.username,
+        team: logItem.team,
+        moves: 1,
+      })
+    } else {
+      players[playerIndex].moves++
+    }
+  })
+
+  return players
+}
+
+function makeTeamListColumn (
+  players: TeamPlayer[],
+  team: Ur.Player,
+): string[] {
+  return players.filter(player => {
+    return player.team === team
+  }).sort((a, b) => {
+    if (a.moves > b.moves) return -1
+    if (a.moves < b.moves) return 1
+    return 0
+  }).map(player => {
+    return `@${player.name} (${player.moves})`
+  })
 }

--- a/src/victory.ts
+++ b/src/victory.ts
@@ -1,29 +1,5 @@
-import Ur from "ur-game"
-import ejs from "ejs"
-
 import { Log } from '@/log'
-
-const PLAYERS_TABLE = `<table>
-  <thead>
-    <tr><th colspan=2>Players this game</th></tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td align="right"><b>Black team</b> :black_circle:</td>
-      <td>:white_circle: <b> White team</b></td>
-    </tr>
-    <tr align="center">
-      <td><%- blackPlayers.join("<br>") %></td>
-      <td><%- whitePlayers.join("<br>") %></td>
-    </tr>
-  </tbody>
-</table>`
-
-interface TeamPlayer {
-  name: string
-  team: Ur.Player
-  moves: number
-}
+import { teamName, makeTeamStats, makeTeamListTable } from '@/teams'
 
 export function makeVictoryMessage (
   log: Log,
@@ -32,53 +8,14 @@ export function makeVictoryMessage (
    * Called at the end of a game. Produces a message to ping participants in a
    * game, show teams, give stats, etc.
    */
-  const players: TeamPlayer[] = []
+  const players = makeTeamStats(log)
 
-  log.internalLog.forEach(logItem => {
-    const playerIndex = players.findIndex(player => {
-      return player.name === logItem.username && player.team === logItem.team
-    })
-    if (playerIndex === -1) {
-      players.push({
-        name: logItem.username,
-        team: logItem.team,
-        moves: 1,
-      })
-    } else {
-      players[playerIndex].moves++
-    }
-  })
-
-  const winningTeam = log.internalLog[log.internalLog.length - 1].team === Ur.BLACK ? "black" : "white"
+  const winningTeam = teamName(log.internalLog[log.internalLog.length - 1].team)
   const moves = players.reduce((moves, player) => moves + player.moves, 0)
 
-  const startingDate = new Date(
-    log.internalLog[0].time
-  )
-  const endingDate = new Date(
-    log.internalLog[log.internalLog.length - 1].time
-  )
+  const startingDate = new Date(log.internalLog[0].time)
+  const endingDate = new Date(log.internalLog[log.internalLog.length - 1].time)
   const hours = (endingDate.getTime() - startingDate.getTime()) / 1000 / 3600
 
-  const blackPlayers = players.filter(player => {
-    return player.team === Ur.BLACK
-  }).sort((a, b) => {
-    if (a.moves > b.moves) return -1
-    if (a.moves < b.moves) return 1
-    return 0
-  }).map(player => {
-    return `@${player.name} (${player.moves})`
-  })
-
-  const whitePlayers = players.filter(player => {
-    return player.team === Ur.WHITE
-  }).sort((a, b) => {
-    if (a.moves > b.moves) return -1
-    if (a.moves < b.moves) return 1
-    return 0
-  }).map(player => {
-    return `@${player.name} (${player.moves})`
-  })
-
-  return `This game has ended! Congratulations to the ${winningTeam} team for their victory.\n\nThis game had ${players.length} players, ${moves} moves, and took ${hours} hours.\n\n${ejs.render(PLAYERS_TABLE, { blackPlayers, whitePlayers })}`
+  return `This game has ended! Congratulations to the ${winningTeam} team for their victory.\n\nThis game had ${players.length} players, ${moves} moves, and took ${hours} hours.\n\n${makeTeamListTable(log)}`
 }

--- a/src/victory.ts
+++ b/src/victory.ts
@@ -17,5 +17,5 @@ export function makeVictoryMessage (
   const endingDate = new Date(log.internalLog[log.internalLog.length - 1].time)
   const hours = (endingDate.getTime() - startingDate.getTime()) / 1000 / 3600
 
-  return `This game has ended! Congratulations to the ${winningTeam} team for their victory.\n\nThis game had ${players.length} players, ${moves} moves, and took ${hours} hours.\n\n${makeTeamListTable(log)}`
+  return `This game has ended! Congratulations to the ${winningTeam} team for their victory.\n\nThis game had ${players.length} players, ${moves} moves, and took ${hours} hours.\n\n${makeTeamListTable(log, false)}`
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "./dist/",
     "noImplicitAny": true,
     "module": "esnext",
-    "target": "esnext",
+    "target": "es2018",
     "strict": true,
     "importHelpers": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Sorting players by alphabet was always a stupid idea. As of right now there's 23 unsuccessful moves to 60 total moves, indicating that it is not intuitive and overall a bad idea.

Instead, players should not be grouped into a team until they have played a game. At that point they should be locked into that team until the game ends.

- [x] Team check can return null
- [x] Handle null case when team check is made
- [x] Use game state to derive teams instead of the alphabet
- [x] Update prose everywhere to reflect new selection system
- [x] Update messages e.g. in new issues to reflect team joining/team participation
- [x] Add a 'who's on each team' to the README

Closes #53.