### PR TITLE
Show previous games on the README

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,6 +2589,15 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compress-tag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compress-tag/-/compress-tag-2.0.0.tgz",
+      "integrity": "sha512-FJboANe4KDqcBOFkEKUW3sW1YUKCeYcFUXY0oBDcJlWanmtrMbVVRGQc9WvYf/yOQoxd78SN9koV1d0DGVm44w==",
+      "dev": true,
+      "requires": {
+        "unraw": "^2.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8769,6 +8778,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
+    },
+    "unraw": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-2.0.0.tgz",
+      "integrity": "sha512-fNpxuL92wTu4guZmjqzVX5EoCmE8pMKJxUJR/Vcg7fA6BRTwnqfCQ/cQd5CBSQsmpkIm8+FNksJqYdxwBFJHng==",
       "dev": true
     },
     "unset-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,6 +1196,12 @@
         "@types/node": "*"
       }
     },
+    "@types/humanize-duration": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@types/humanize-duration/-/humanize-duration-3.18.1.tgz",
+      "integrity": "sha512-MUgbY3CF7hg/a/jogixmAufLjJBQT7WEf8Q+kYJkOc47ytngg1IuZobCngdTjAgY83JWEogippge5O5fplaQlw==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -4480,6 +4486,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
+    "humanize-duration": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.24.0.tgz",
+      "integrity": "sha512-B3udnqisaDeRsvUSb+5n2hjxhABI9jotB+i1IEhgHhguTeM5LxIUKoVIu7UpeyaPOygr/Fnv7UhOi45kYYG+tg==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
     "clean-webpack-plugin": "^3.0.0",
+    "compress-tag": "^2.0.0",
     "core-js": "^3.6.5",
     "crypto-random-string": "^3.2.0",
     "eslint": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@octokit/rest": "^16.43.2",
     "@types/ejs": "^3.0.4",
+    "@types/humanize-duration": "^3.18.1",
     "@types/jest": "^26.0.5",
     "@types/lodash": "^4.14.158",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
@@ -31,6 +32,7 @@
     "crypto-random-string": "^3.2.0",
     "eslint": "^7.5.0",
     "github-script": "git+https://github.com/actions/github-script.git#v2.0.0",
+    "humanize-duration": "^3.24.0",
     "jest": "^26.1.0",
     "source-map-loader": "^1.0.1",
     "svgo": "^1.3.2",

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -57,12 +57,8 @@ What would you like to do?
 
 ## Previous games
 
-<% previousGames.forEach((game, index) => { -%>
-1. A game started on <%= game.startDate %> by <%= game.startUser %>, and
-   ended on <%= game.endDate %> in a win for the
-   <%= game.winner === "b" ? ":black_circle:black" : ":white_circle:white" %>
-   team.
-   [See the winning issue!](https://github.com/rossjrw/rossjrw/issues/269)
+<% previousGames.forEach(summary => { -%>
+1. <%= summary %>
 <% }) -%>
 
 </details>

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -1,7 +1,7 @@
 Welcome to my Github profile!
 We're playing
 [The Royal Game of Ur](https://en.wikipedia.org/wiki/Royal_Game_of_Ur).
-<%= state.currentPlayer ? "**This game is in progress,** but you can join!" : "**This game has ended!**" %>
+<%= state.currentPlayer ? "**Game #<%= previousGames.length + 1 %> is in progress,** but you can join!" : "**This game has ended!**" %>
 
 <% if (state.currentPlayer === undefined) { -%>
   This game has finished, so we're just waiting for someone to click _"Start a
@@ -41,7 +41,7 @@ What would you like to do?
 
 -----
 
-<details><summary>The game so far</summary>
+<details><summary>Game #<%= previousGames.length + 1 %> so far</summary>
 
 ## Who's on each team?
 

--- a/src/README.ejs
+++ b/src/README.ejs
@@ -55,6 +55,16 @@ What would you like to do?
   | <%= logItem[0] %> | **<%= index %>** | <%= logItem[1] %> | <%= logItem[2] %> | <%= logItem[3] %> |
 <% }) -%>
 
+## Previous games
+
+<% previousGames.forEach((game, index) => { -%>
+1. A game started on <%= game.startDate %> by <%= game.startUser %>, and
+   ended on <%= game.endDate %> in a win for the
+   <%= game.winner === "b" ? ":black_circle:black" : ":white_circle:white" %>
+   team.
+   [See the winning issue!](https://github.com/rossjrw/rossjrw/issues/269)
+<% }) -%>
+
 </details>
 
 -----

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -8,6 +8,7 @@ import { updateSvg } from '@/updateSvg'
 import { Change } from '@/play'
 import { Log } from '@/log'
 import { makeTeamListTable, teamName } from '@/teams'
+import { listPreviousGames } from '@/victory'
 
 export async function generateReadme (
   state: Ur.State,
@@ -92,6 +93,8 @@ export async function generateReadme (
   })
 
   const teamTable = makeTeamListTable(log, true)
+
+  const previousGames = listPreviousGames("games", octokit, context)
 
   const readme = ejs.render(
     template,

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -95,7 +95,7 @@ export async function generateReadme (
 
   const readme = ejs.render(
     template,
-    { actions, state, logItems, context, teamTable }
+    { actions, state, logItems, context, teamTable, previousGames }
   )
 
   const currentReadmeFile = await octokit.repos.getContents({

--- a/src/victory.ts
+++ b/src/victory.ts
@@ -1,4 +1,8 @@
-import { Log } from '@/log'
+import { Octokit } from "@octokit/rest/index"
+import { Context } from "@actions/github/lib/context"
+import { compress } from "compress-tag"
+
+import { Log, LogItem } from '@/log'
 import { teamName, makeTeamStats, makeTeamListTable } from '@/teams'
 
 export function makeVictoryMessage (
@@ -18,4 +22,69 @@ export function makeVictoryMessage (
   const hours = (endingDate.getTime() - startingDate.getTime()) / 1000 / 3600
 
   return `This game has ended! Congratulations to the ${winningTeam} team for their victory.\n\nThis game had ${players.length} players, ${moves} moves, and took ${hours} hours.\n\n${makeTeamListTable(log, false)}`
+}
+
+export async function listPreviousGames (
+  gamePath: string,
+  octokit: Octokit,
+  context: Context,
+): Promise<string[]> {
+  /**
+   * Generates a list of previous games.
+   */
+  const gameDirPath = gamePath.substring(0, gamePath.lastIndexOf("/"))
+  const logDir = await octokit.repos.getContents({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    ref: "play",
+    path: gameDirPath,
+    mediaType: { format: "raw" },
+  })
+  if (!Array.isArray(logDir.data)) {
+    throw new Error("GAMEDIR_IS_FILE")
+  }
+
+  const gameFiles = logDir.data.filter(dirObject => {
+    return dirObject.type === "file"
+  })
+
+  const gameLogs: LogItem[][] = await Promise.all(gameFiles.map(async file => {
+    const gameFile = await octokit.repos.getContents({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: "play",
+      path: file.path,
+      mediaType: { format: "raw" },
+    })
+    if (Array.isArray(gameFile.data)) {
+      throw new Error("GAMEFILE_IS_DIR")
+    }
+    return JSON.parse(
+      Buffer.from(gameFile.data.content!, "base64").toString()
+    )
+  }))
+
+  const gameStrings = gameLogs.map(log => {
+    const game = {
+      firstMove: log[0],
+      lastMove: log[log.length - 1]
+    }
+    return compress`
+      A game started on ${new Date(game.firstMove.time).toUTCString()}
+      by <b>
+        <a href="https://github.com/${game.firstMove.username}">
+          @${game.firstMove.username}
+        </a>
+      </b>
+      and ended on ${new Date(game.lastMove.time).toUTCString()}
+      in a win for the ${
+        game.lastMove.team === "b" ?
+          ":black_circle:black" :
+          ":white_circle:white"
+      } team.
+      [#${game.lastMove.issue}](https://github.com/rossjrw/rossjrw/issues/${game.lastMove.issue})
+    `
+  })
+
+  return gameStrings
 }


### PR DESCRIPTION
Now that the first game is finished, a list of previous games should be shown on the front README, if for nothing else then to prove to viewers that this thing isn't 20 minutes old.

- [x] Add a previous games section to the README
- [x] Construct a previous games object from the logs
- [x] Inform the reader which game index this is
- [x] Generate some fun stats about the game (maybe the current game too?)