### PR TITLE
Skip single moves

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -1,0 +1,23 @@
+name: build
+on:
+  push:
+    branches: [source]
+  pull_request:
+    branches: [source]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        if: github.ref == 'refs/heads/source'
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
+          BRANCH: compiled
+          FOLDER: dist

--- a/migrations/add-explicit-automatic-indicators.py
+++ b/migrations/add-explicit-automatic-indicators.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+This script changes log files from assuming whether an event is automatic
+based on the action type to having explicit automatic indicators.
+"""
+
+import json
+import sys
+
+# Make sure we got a filename on the command line.
+if len(sys.argv) < 2:
+    print(f"Usage: python3.8 {sys.argv[0]} FILENAME")
+    exit(1)
+
+logFileName = sys.argv[1]
+
+with open(logFileName, 'r') as logFile:
+    log = json.loads(logFile.read())
+
+for logItem in log:
+    logItem['initiatedByPlayer'] = logItem['action'] == "move"
+
+with open(logFileName, 'w') as logFile:
+    logFile.write(json.dumps(log, indent=2))

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "source-map-loader": "^1.0.1",
         "svgo": "^1.3.2",
         "ts-loader": "^8.0.1",
-        "typescript": "^3.9.7",
+        "typescript": "^4.4.4",
         "webpack": "^4.43.0",
         "webpack-cli": "^3.3.12"
       }
@@ -10371,9 +10371,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20582,9 +20582,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "source-map-loader": "^1.0.1",
     "svgo": "^1.3.2",
     "ts-loader": "^8.0.1",
-    "typescript": "^3.9.7",
+    "typescript": "^4.4.4",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"
   },

--- a/src/analyseMove.ts
+++ b/src/analyseMove.ts
@@ -8,20 +8,20 @@ export interface Events {
   gameWon: boolean
 }
 
+/**
+ * Analyses what events happened, or predicts what events will happen, for a
+ * given move.
+ *
+ * @param state: The current state of the board.
+ * @param fromPosition: The position that a piece is moving from.
+ * @param toPosition: The position that a pice is moving to.
+ * @returns A dict of events that could happen and whether or not they did.
+ */
 export function analyseMove(
   state: Ur.State,
   fromPosition: number,
   toPosition: number
 ): Events {
-  /**
-   * Analyses what events happened, or predicts what events will happen, for a
-   * given move.
-   *
-   * @param state: The current state of the board.
-   * @param fromPosition: The position that a piece is moving from.
-   * @param toPosition: The position that a pice is moving to.
-   * @returns A dict of events that could happen and whether or not they did.
-   */
   const newState = Ur.takeTurn(state, state.currentPlayer!, fromPosition)
   const events = {
     // Was a rosette claimed?

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -3,18 +3,17 @@ import { Context } from "@actions/github/lib/context"
 
 import { Change } from "@/play"
 
+/**
+ * From the given list of changes, makes a single commit to implement them.
+ *
+ * @param changes: The list of changes to make.
+ */
 export async function makeCommit(
   message: string,
   changes: Change[],
   octokit: Octokit,
   context: Context
 ): Promise<void> {
-  /**
-   * From the given list of changes, makes a single commit to implement them.
-   *
-   * @param changes: The list of changes to make.
-   */
-
   // Grab the SHA of the latest commit
   const remoteCommits = await octokit.repos.listCommits({
     owner: context.repo.owner,

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,12 @@ interface ErrorDescriptions {
   [error_type: string]: string
 }
 
+/**
+ * Handles execution errors by reporting the problem back to the user and
+ * closing the issue.
+ *
+ * @param error: The error to report with an ID matching the desc object.
+ */
 export function handleError(
   error: Error,
   log: Log,
@@ -19,12 +25,6 @@ export function handleError(
   context: Context,
   core: typeof _core
 ): void {
-  /**
-   * Handles execution errors by reporting the problem back to the user and
-   * closing the issue.
-   *
-   * @param error: The error to report with an ID matching the desc object.
-   */
   const playerTeam = getPlayerTeam(context.actor, log)
 
   const ERROR_DESC: ErrorDescriptions = {

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -12,6 +12,13 @@ import { Log } from "@/log"
 import { getOppositeTeam, makeTeamListTable, teamName } from "@/teams"
 import { listPreviousGames } from "@/victory"
 
+/**
+ * Generates the new README file based on the current state of the game.
+ *
+ * @param state: The current state of the board, as of right now.
+ * @param gamePath: The location of the current game's state file.
+ * @returns An array of changes to add to the commit.
+ */
 export async function generateReadme(
   state: Ur.State,
   gamePath: string,
@@ -19,13 +26,6 @@ export async function generateReadme(
   context: Context,
   log: Log
 ): Promise<Change[]> {
-  /**
-   * Generates the new README file based on the current state of the game.
-   *
-   * @param state: The current state of the board, as of right now.
-   * @param gamePath: The location of the current game's state file.
-   * @returns An array of changes to add to the commit.
-   */
   let changes: Change[] = []
 
   // Update the SVG to represent the new game board

--- a/src/getFile.ts
+++ b/src/getFile.ts
@@ -1,6 +1,9 @@
 import { Octokit } from "@octokit/rest/index"
 import { Context } from "@actions/github/lib/context"
 
+/**
+ * Gets the content of a file, or returns null if it doesn't exist.
+ */
 export async function getFile(
   branch: "source" | "play",
   gamePath: string,
@@ -8,10 +11,6 @@ export async function getFile(
   octokit: Octokit,
   context: Context
 ): Promise<Octokit.Response<Octokit.ReposGetContentsResponse> | null> {
-  /**
-   * Gets the content of a file, or returns null if it doesn't exist.
-   */
-
   // Grab the content of the current board from file
   try {
     return await octokit.repos.getContents({

--- a/src/getFile.ts
+++ b/src/getFile.ts
@@ -21,7 +21,7 @@ export async function getFile(
       path: `${gamePath}${filename === null ? "" : `/${filename}`}`,
       mediaType: { format: "raw" },
     })
-  } catch (error) {
+  } catch (error: any) {
     if (error.status === 404) {
       // There's no game file! That's probably fine
       return null

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -1,6 +1,9 @@
 import { Octokit } from "@octokit/rest/index"
 import { Context } from "@actions/github/lib/context"
 
+/**
+ * Adds a reaction to the triggering issue.
+ */
 export function addReaction(
   reaction: NonNullable<
     Parameters<typeof octokit.reactions.createForIssue>[0]
@@ -8,9 +11,6 @@ export function addReaction(
   octokit: Octokit,
   context: Context
 ): void {
-  /**
-   * Adds a reaction to the triggering issue.
-   */
   octokit.reactions.createForIssue({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -19,14 +19,14 @@ export function addReaction(
   })
 }
 
+/**
+ * Adds labels to the triggering issue.
+ */
 export function addLabels(
   labels: string[],
   octokit: Octokit,
   context: Context
 ): void {
-  /**
-   * Adds labels to the triggering issue.
-   */
   octokit.issues.addLabels({
     owner: context.repo.owner,
     repo: context.repo.repo,

--- a/src/log.ts
+++ b/src/log.ts
@@ -18,6 +18,28 @@ export interface LogItem {
   roll: number | null
 }
 
+/**
+ * A new entry to be added to the log.
+ *
+ * @property action - The name of the action.
+ * @property team - The team of the current turn.
+ *
+ * If the action is a move, the following properties must not be null:
+ *
+ * @property roll - The value of the current dice roll.
+ * @property fromPosition - The starting position of the piece that moved.
+ * @property toPosition - The final position of the piece that moved.
+ * @property events - Object of events that happened during the turn.
+ */
+export type LogEntryNew = {
+  action: "new" | "move" | "pass"
+  team: Ur.Player
+  roll: number | null
+  fromPosition: number | null
+  toPosition: number | null
+  events: Events | null
+}
+
 export class Log {
   username: string
   issue: number
@@ -73,34 +95,18 @@ export class Log {
     this.lastCommitSha = lastCommit.data.object.sha
   }
 
-  addToLog(
-    action: "new" | "move" | "pass",
-    team: Ur.Player,
-    roll: number | null,
-    fromPosition: number | null,
-    toPosition: number | null,
-    events: Events | null
-  ): void {
+  addToLog(entry: LogEntryNew): void {
     /**
      * Adds an item to the internal log.
      *
-     * @param action: The action this player took.
-     * @param message: A verbose description of the action.
-     * @param team: The team that this player is on.
      * @returns An array of changes to add to the commit.
      */
-    const logItem: LogItem = {
+    const logItem: LogItem = Object.assign(entry, {
       username: this.username,
       issue: this.issue,
       time: new Date().toISOString(),
-      team,
-      action,
       boardImage: null,
-      events,
-      fromPosition,
-      toPosition,
-      roll,
-    }
+    })
     this.internalLog.push(logItem)
   }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -11,6 +11,7 @@ export interface LogItem {
   time: string
   team: Ur.Player
   action: "new" | "move" | "pass"
+  initiatedByPlayer: boolean
   boardImage: string | null
   events: Events | null
   fromPosition: number | null
@@ -33,6 +34,7 @@ export interface LogItem {
  */
 export type LogEntryNew = {
   action: "new" | "move" | "pass"
+  initiatedByPlayer: boolean
   team: Ur.Player
   roll: number | null
   fromPosition: number | null

--- a/src/log.ts
+++ b/src/log.ts
@@ -68,12 +68,12 @@ export class Log {
     this.lastCommitSha = null
   }
 
+  /**
+   * Grabs the contents of the log file and puts it into the internal log.
+   * This function should be called only once, before any extra log items
+   * have been added.
+   */
   async prepareInitialLog(): Promise<void> {
-    /**
-     * Grabs the contents of the log file and puts it into the internal log.
-     * This function should be called only once, before any extra log items
-     * have been added.
-     */
     const logFile = await this.octokit.repos.getContents({
       owner: this.context.repo.owner,
       repo: this.context.repo.repo,
@@ -97,12 +97,12 @@ export class Log {
     this.lastCommitSha = lastCommit.data.object.sha
   }
 
+  /**
+   * Adds an item to the internal log.
+   *
+   * @returns An array of changes to add to the commit.
+   */
   addToLog(entry: LogEntryNew): void {
-    /**
-     * Adds an item to the internal log.
-     *
-     * @returns An array of changes to add to the commit.
-     */
     const logItem: LogItem = Object.assign(entry, {
       username: this.username,
       issue: this.issue,
@@ -112,29 +112,28 @@ export class Log {
     this.internalLog.push(logItem)
   }
 
+  /**
+   * Creates an absolute reference for the previous board's image and adds
+   * that value to the log.
+   *
+   * I want to retain an image for every state of the board. In order to do
+   * that I will be associating each move in the log with the image of the
+   * board state that it resulted in. These images will be provided by URL
+   * using the commit SHA as an absolute reference.
+   *
+   * When any given action is logged for the first time, at that point in
+   * time, the SHA of that commit is not known as it has not yet been made,
+   * so there's no point adding the image to the log at that time - I mark
+   * it null.
+   *
+   * On the next action, this function should be called to add the previous
+   * commit's SHA - which is now known - to the image. This will enable the
+   * creation of an absolute link to the board state at that action. Even if
+   * more commits are added in between, so long as the image was not changed,
+   * the image will still work. The only thing that could break it is
+   * rewriting history - but even then those commits might still be saved.
+   */
   linkPreviousBoardState(): void {
-    /**
-     * Creates an absolute reference for the previous board's image and adds
-     * that value to the log.
-     *
-     * I want to retain an image for every state of the board. In order to do
-     * that I will be associating each move in the log with the image of the
-     * board state that it resulted in. These images will be provided by URL
-     * using the commit SHA as an absolute reference.
-     *
-     * When any given action is logged for the first time, at that point in
-     * time, the SHA of that commit is not known as it has not yet been made,
-     * so there's no point adding the image to the log at that time - I mark
-     * it null.
-     *
-     * On the next action, this function should be called to add the previous
-     * commit's SHA - which is now known - to the image. This will enable the
-     * creation of an absolute link to the board state at that action. Even if
-     * more commits are added in between, so long as the image was not changed,
-     * the image will still work. The only thing that could break it is
-     * rewriting history - but even then those commits might still be saved.
-     */
-
     // The board image for the current round has already been added, so the
     // second-to-last image needs to be linked
     if (
@@ -155,13 +154,13 @@ export class Log {
     }
   }
 
+  /**
+   * Make the changes to the log file as described by the internal log. This
+   * method should be called only once all log items have been added.
+   *
+   * @returns An array of changes to add to the commit.
+   */
   makeLogChanges(): Change[] {
-    /**
-     * Make the changes to the log file as described by the internal log. This
-     * method should be called only once all log items have been added.
-     *
-     * @returns An array of changes to add to the commit.
-     */
     const changes: Change[] = []
 
     changes.push({

--- a/src/move.ts
+++ b/src/move.ts
@@ -168,6 +168,7 @@ export async function makeMove(
     // Update the log with this action
     log.addToLog({
       action: "move",
+      initiatedByPlayer: true,
       team: state.currentPlayer,
       roll: state.diceResult,
       fromPosition,
@@ -196,6 +197,7 @@ export async function makeMove(
   ) {
     log.addToLog({
       action: "pass",
+      initiatedByPlayer: false,
       team: newState.currentPlayer!,
       roll: newState.diceResult!,
       fromPosition: null,

--- a/src/move.ts
+++ b/src/move.ts
@@ -13,6 +13,15 @@ import { Log } from "@/log"
 import { makeVictoryMessage } from "@/victory"
 import { getOppositeTeam, teamName } from "@/teams"
 
+/**
+ * Called when a player uses the "move" command. Executes that move onto the
+ * current state.
+ *
+ * @param state: The current state of the game.
+ * @param move: The move the player wants to make.
+ * @param gamePath: The location of the current game's state file.
+ * @returns An array of changes to add to the commit.
+ */
 export async function makeMove(
   state: Ur.State,
   move: string,
@@ -21,15 +30,6 @@ export async function makeMove(
   context: Context,
   log: Log
 ): Promise<Change[]> {
-  /**
-   * Called when a player uses the "move" command. Executes that move onto the
-   * current state.
-   *
-   * @param state: The current state of the game.
-   * @param move: The move the player wants to make.
-   * @param gamePath: The location of the current game's state file.
-   * @returns An array of changes to add to the commit.
-   */
   let changes: Change[] = []
 
   if (!state.currentPlayer) {

--- a/src/move.ts
+++ b/src/move.ts
@@ -166,14 +166,14 @@ export async function makeMove(
     })
 
     // Update the log with this action
-    log.addToLog(
-      "move",
-      state.currentPlayer,
-      state.diceResult,
+    log.addToLog({
+      action: "move",
+      team: state.currentPlayer,
+      roll: state.diceResult,
       fromPosition,
       toPosition,
-      events
-    )
+      events,
+    })
 
     // If the game was won, leave a message to let everyone know
     if (events.gameWon) {
@@ -194,14 +194,14 @@ export async function makeMove(
     !events?.gameWon &&
     Object.keys(newState.possibleMoves!).length === 0
   ) {
-    log.addToLog(
-      "pass",
-      newState.currentPlayer!,
-      newState.diceResult!,
-      null,
-      null,
-      null
-    )
+    log.addToLog({
+      action: "pass",
+      team: newState.currentPlayer!,
+      roll: newState.diceResult!,
+      fromPosition: null,
+      toPosition: null,
+      events: null,
+    })
     changes = changes.concat(
       await makeMove(newState, "pass", gamePath, octokit, context, log)
     )

--- a/src/move.ts
+++ b/src/move.ts
@@ -186,12 +186,14 @@ export async function makeMove(
     }
   }
 
+  // Execute automatic moves
+
+  // If there are no possible moves and the game is not finished, pass.
+  // Note that the events object is undefined if the last move was also a pass
   if (
     !events?.gameWon &&
     Object.keys(newState.possibleMoves!).length === 0
   ) {
-    // If there are no possible moves, pass this turn, unless the game is done
-    // The events object is undefined if the last move was also a pass
     log.addToLog(
       "pass",
       newState.currentPlayer!,
@@ -213,6 +215,15 @@ export async function makeMove(
       path: `${gamePath}/state.json`,
       content: JSON.stringify(newState, null, 2),
     })
+  }
+
+  // If there is only one possible move and that move is not a winning
+  // move, execute it without asking for player input.
+  if (Object.keys(newState.possibleMoves!).length === 1) {
+    const move = Object.entries(newState.possibleMoves!)[0]
+    const moveEvents = analyseMove(newState, parseInt(move[0]), move[1])
+    if (!moveEvents.gameWon) {
+    }
   }
 
   return changes

--- a/src/new.ts
+++ b/src/new.ts
@@ -9,6 +9,15 @@ import { Change } from "@/play"
 import { Log } from "@/log"
 import { teamName } from "@/teams"
 
+/**
+ * Called when a player uses the "new" command.
+ *
+ * I don't want this to happen willy-nilly, so I might add some restriction
+ * here - maybe no moves for a few hours or something.
+ *
+ * @param gamePath: The location of the current game.
+ * @param oldGamePath: Where old games should be kept.
+ */
 export async function resetGame(
   gamePath: string,
   oldGamePath: string,
@@ -16,15 +25,6 @@ export async function resetGame(
   context: Context,
   log: Log
 ): Promise<Change[]> {
-  /**
-   * Called when a player uses the "new" command.
-   *
-   * I don't want this to happen willy-nilly, so I might add some restriction
-   * here - maybe no moves for a few hours or something.
-   *
-   * @param gamePath: The location of the current game.
-   * @param oldGamePath: Where old games should be kept.
-   */
   let changes: Change[] = []
 
   // Move the old log.json to another directory - don't care about state

--- a/src/new.ts
+++ b/src/new.ts
@@ -60,7 +60,14 @@ export async function resetGame(
   log.internalLog = []
 
   // Update the log with this action
-  log.addToLog("new", newState.currentPlayer!, null, null, null, null)
+  log.addToLog({
+    action: "new",
+    team: newState.currentPlayer!,
+    roll: null,
+    fromPosition: null,
+    toPosition: null,
+    events: null,
+  })
 
   // Update README.md with the new state
   changes = changes.concat(

--- a/src/new.ts
+++ b/src/new.ts
@@ -62,6 +62,7 @@ export async function resetGame(
   // Update the log with this action
   log.addToLog({
     action: "new",
+    initiatedByPlayer: false,
     team: newState.currentPlayer!,
     roll: null,
     fromPosition: null,

--- a/src/play.ts
+++ b/src/play.ts
@@ -97,7 +97,7 @@ export default async function play(
     )
 
     addReaction("rocket", octokit, context)
-  } catch (error) {
+  } catch (error: any) {
     // If there was an error, forward it to the user, then stop
     handleError(error, log, octokit, context, core)
     return

--- a/src/play.ts
+++ b/src/play.ts
@@ -16,23 +16,23 @@ export interface Change {
   content: string | null
 }
 
+/**
+ * Let's play Ur!
+ *
+ * This project is inspired by timburgan/timburgan - thank you Tim!
+ *
+ * Recieves parameters from actions/github-script:
+ * @param title: The title of the triggering issue.
+ * @param octokit: octokit/rest.js client.
+ * @param context: Workflow context object.
+ * @returns void: At least until I work out what this should do!
+ */
 export default async function play(
   title: string,
   octokit: Octokit,
   context: Context,
   core: typeof _core
 ): Promise<void> {
-  /**
-   * Let's play Ur!
-   *
-   * This project is inspired by timburgan/timburgan - thank you Tim!
-   *
-   * Recieves parameters from actions/github-script:
-   * @param title: The title of the triggering issue.
-   * @param octokit: octokit/rest.js client.
-   * @param context: Workflow context object.
-   * @returns void: At least until I work out what this should do!
-   */
   // The Octokit client comes pre-authenticated, so there's no need to
   // instantiate it.
 
@@ -104,12 +104,12 @@ export default async function play(
   }
 }
 
+/**
+ * Parses the issue title into move instructions.
+ *
+ * @param title: The title of the issue.
+ */
 function parseIssueTitle(title: string): ["new" | "move", string, number] {
-  /**
-   * Parses the issue title into move instructions.
-   *
-   * @param title: The title of the issue.
-   */
   const [gamename, command, move, gameId] = title.split("-")
   if (!gamename || gamename !== "ur") {
     throw new Error("WRONG_GAME")

--- a/src/player.ts
+++ b/src/player.ts
@@ -2,17 +2,17 @@ import Ur from "ur-game"
 
 import { Log } from "@/log"
 
+/**
+ * Checks if a player is on the given team.
+ *
+ * @param username: The player's name.
+ * @param team: The team to check against.
+ */
 export function playerIsOnTeam(
   username: string,
   team: Ur.Player,
   log: Log
 ): boolean {
-  /**
-   * Checks if a player is on the given team.
-   *
-   * @param username: The player's name.
-   * @param team: The team to check against.
-   */
   const playerTeam = getPlayerTeam(username, log)
   if (playerTeam === undefined) {
     // A player who hasn't played yet is allowed on either team
@@ -22,22 +22,22 @@ export function playerIsOnTeam(
   return playerTeam === team
 }
 
+/**
+ * Checks what team a player is on.
+ */
 export function getPlayerTeam(
   username: string,
   log: Log
 ): Ur.Player | undefined {
-  /**
-   * Checks what team a player is on.
-   */
   return log.internalLog.find((item) => item.username === username)?.team
 }
 
+/**
+ * Returns the issue number that determined a player's team for this game.
+ */
 export function getPlayerTeamSource(
   username: string,
   log: Log
 ): number | undefined {
-  /**
-   * Returns the issue number that determined a player's team for this game.
-   */
   return log.internalLog.find((item) => item.username === username)?.issue
 }

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -31,16 +31,16 @@ export function getOppositeTeam(
   return undefined
 }
 
+/**
+ * Makes a table containing team members.
+ *
+ * @param hasPlayerLinks: Players as hyperlinks? Required for README, but not
+ * required for issues.
+ */
 export function makeTeamListTable(
   log: Log,
   hasPlayerLinks: boolean
 ): string {
-  /**
-   * Makes a table containing team members.
-   *
-   * @param hasPlayerLinks: Players as hyperlinks? Required for README, but not
-   * required for issues.
-   */
   const PLAYERS_TABLE = `<table>
     <thead>
       <tr><th colspan=2>Players in this game</th></tr>

--- a/src/updateSvg.ts
+++ b/src/updateSvg.ts
@@ -6,6 +6,16 @@ import { range } from "lodash"
 import { Change } from "@/play"
 import { getFile } from "@/getFile"
 
+/**
+ * Generates an SVG to visually represent the current board state.
+ *
+ * Saves the resulting SVG to games/current/board.svg.
+ *
+ * @param state: The current state of the game board.
+ * @param gamePath: The path to the current game's info dir.
+ * @param baseSvgPath: The path to the SVG template file.
+ * @returns An array of changes to add to the commit.
+ */
 export async function updateSvg(
   state: State,
   gamePath: string,
@@ -13,16 +23,6 @@ export async function updateSvg(
   octokit: Octokit,
   context: Context
 ): Promise<Change[]> {
-  /**
-   * Generates an SVG to visually represent the current board state.
-   *
-   * Saves the resulting SVG to games/current/board.svg.
-   *
-   * @param state: The current state of the game board.
-   * @param gamePath: The path to the current game's info dir.
-   * @param baseSvgPath: The path to the SVG template file.
-   * @returns An array of changes to add to the commit.
-   */
   const changes: Change[] = []
 
   // Delete the old board image
@@ -100,20 +100,20 @@ export async function updateSvg(
   return changes
 }
 
+/**
+ * Hides the SVG element that has the given ID.
+ *
+ * All elements in the SVG are displayed by default, and must be turned off
+ * in order to produce a coherent image. The reason that the far more
+ * sensible approach of turning things on has not been taken is because a) it
+ * makes it hard to edit the base file when everything is hidden by default
+ * b) the base file just looks way cooler now
+ *
+ * @param svg: The contents of the SVG as text.
+ * @param elementId: The ID to find.
+ * @returns The updated contents of the SVG.
+ */
 function hideSvgElement(svg: string, elementId: string): string {
-  /**
-   * Hides the SVG element that has the given ID.
-   *
-   * All elements in the SVG are displayed by default, and must be turned off
-   * in order to produce a coherent image. The reason that the far more
-   * sensible approach of turning things on has not been taken is because a) it
-   * makes it hard to edit the base file when everything is hidden by default
-   * b) the base file just looks way cooler now
-   *
-   * @param svg: The contents of the SVG as text.
-   * @param elementId: The ID to find.
-   * @returns The updated contents of the SVG.
-   */
   // The ID is always the first attribute in a node, thankfully
   // Also, all nodes are written on a single line
 

--- a/src/victory.ts
+++ b/src/victory.ts
@@ -17,11 +17,11 @@ import dateformat from "dateformat"
 import { Log, LogItem } from "@/log"
 import { teamName, makeTeamStats, makeTeamListTable } from "@/teams"
 
+/**
+ * Called at the end of a game. Produces a message to ping participants in a
+ * game, show teams, give stats, etc.
+ */
 export function makeVictoryMessage(log: Log): string {
-  /**
-   * Called at the end of a game. Produces a message to ping participants in a
-   * game, show teams, give stats, etc.
-   */
   const players = makeTeamStats(log)
 
   const winningTeam = teamName(
@@ -47,17 +47,17 @@ export function makeVictoryMessage(log: Log): string {
   `
 }
 
+/**
+ * Generates a list of previous games from the logs in the game directory.
+ *
+ * @param gamePath: The path to the directory that contains the current game.
+ * This is expected to be inside the directory that contains previous games.
+ */
 export async function listPreviousGames(
   gamePath: string,
   octokit: Octokit,
   context: Context
 ): Promise<string[]> {
-  /**
-   * Generates a list of previous games from the logs in the game directory.
-   *
-   * @param gamePath: The path to the directory that contains the current game.
-   * This is expected to be inside the directory that contains previous games.
-   */
   const gameDirPath = gamePath.substring(0, gamePath.lastIndexOf("/"))
   const logDir = await octokit.repos.getContents({
     owner: context.repo.owner,


### PR DESCRIPTION
When there is only a single move to make, there is no choice for a player and therefore what little fun this game has is removed. In this situation, the move should be made automatically.

Resolves #1123; closes #1293.

- [ ] Perform the move automatically if there's only a single choice
- [x] Do not move automatically if that move is a winning move (a player should be allowed to claim that themselves)
- [ ] Report a summary of all executed moves in the reply to the issue, including any passes
- [ ] In the reply, if the resultant turn is the same colour as the team of the player who made the issue, let them know that they can make another move
  * This can happen via automatic passes, automatic moves as a result of this PR, or rosettes
- [ ] Show automatic moves in the main log correctly
   * Do not incorrectly attribute them to the current player
   * The code currently assumes that if the move is a pass, it was made by the game and everything else is done by a player - either this needs to be corrected with explicit data, or another assumption can be 
     * The log does not currently distinguish between explicit actions and automatic actions
     * One possible assumption could be that only the first move made on a player's turn can be attributed to that player and all subsequent moves can be attributed to the game (not currently feasible - turns are counted by the number of actions)