### PR TITLE
Restrict GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/play.yml
+++ b/.github/workflows/play.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   play:
     runs-on: ubuntu-latest
+    # Restrict permissions for the action
+    # All others are disabled by default
+    permissions:
+      contents: write
+      issues: write
     # Only do anything if the issue says it's a move
     if: startsWith(github.event.issue.title, 'ur-')
     steps:


### PR DESCRIPTION
This commit restricts what GITHUB_TOKEN can do.

As per [this blog post](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/), all other permissions are set to `none` by default if not specified under the jobs permissions.

`contents` is used to access the repository tree, while `issues` is used to (of course) access issues.

If either of these permissions are *not* `write`, the workflow fails. If anything requires neither of these permissions, it will be unable to access them.