### PR TITLE
Don't ping players in commit messages

### DIFF
--- a/src/play.ts
+++ b/src/play.ts
@@ -86,7 +86,7 @@ export default async function play(
 
     // All the changes have been collected - commit them
     await makeCommit(
-      `@${context.actor} ${
+      `(${context.actor}) ${
         command === "new"
           ? "Start a new game"
           : `Move ${teamName(state.currentPlayer)} ${move}`


### PR DESCRIPTION
Closes #1216.

Not totally sure on the formatting:

Options | Thoughts
--- | ---
@rossjrw Move white 2@2 (#1307) | Current
(rossjrw) Move white 2@2 (#1307)
rossjrw: Move white 2@2 (#1307) | Inconsistent with [conventional commits](https://www.conventionalcommits.org)
rossjrw &mdash; Move white 2@2 (#1307)
rossjrw moved white 2@2 (#1307)
rossjrw :white_circle: 2@2 (#1307)<br>rossjrw :white_circle: ⚔️ 2@2 (#1307)<br>rossjrw :white_circle: 2@2, ⚫ pass (#1307) | Only one commit is seen at a time from the readme, so variety would be wasted (but it'd look nice from the commit history)<br>Although this repo does have a defined emoji language, emojis are not exactly verbose (but neither is the current commit message)<br>Emojis could concisely stack to represent multiple actions (#1211)<br>Looks sort of messy, at least with this notation - is there a better one? (have asked in the https://royalur.net/ discord)
