### PR TITLE
Prevent starting a new game while one is in progress.

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -43,6 +43,8 @@ export function handleError(
     // Execution errors
     MOVE_WHEN_GAME_ENDED:
       "You can't make a move when the game has finished! You'll have to start a new game instead.",
+    UNFINISHED_GAME_NEW:
+      "You can't start a new game while the current game is still in progress! Wait until someone wins, then try again.",
     WRONG_TEAM: `Sorry, you're on the ${teamName(
       playerTeam,
     )} team, but it's ${teamName(

--- a/src/play.ts
+++ b/src/play.ts
@@ -73,6 +73,9 @@ export default async function play(
 
     // Collect changes for each command
     if (command === "new") {
+      if (state.currentPlayer) {
+        throw new Error("UNFINISHED_GAME_NEW")
+      }
       changes = changes.concat(
         await resetGame(gamePath, oldGamePath, octokit, context, log),
         log.makeLogChanges(),


### PR DESCRIPTION
Reject ur-new commands when currentPlayer is set, using the UNFINISHED_GAME_NEW error described in #1213.

Prevents starting a new game while `currentPlayer` is set.
cc @rossjrw
Fixes #1213