### PR TITLE
Add a main-screen notice when a turn is auto-passed.

### DIFF
--- a/src/README.ejs
+++ b/src/README.ejs
@@ -17,6 +17,10 @@ You're on a team! :wave:
   <img src="https://raw.githubusercontent.com/<%- context.repo.owner %>/<%- context.repo.repo %>/play/games/current/board.<%- logItems[logItems.length - 1].issue %>.svg">
 </p>
 
+<% if (skipNotice) { -%>
+<p align="center"><b><%- skipNotice %></b></p>
+<% } -%>
+
 <% if (state.currentPlayer) { -%>
 **<%- state.currentPlayer === "b" ? ":black_circle:Black" : ":white_circle:White" %> team:** You rolled a <%- state.diceResult %>!
 <% } -%>

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -164,6 +164,16 @@ export async function generateReadme(
 
   const previousGames = await listPreviousGames(gamePath, octokit, context)
 
+  const latestLogEntry = log.internalLog[log.internalLog.length - 1]
+  const skipNotice =
+    latestLogEntry?.action === "pass"
+      ? compress`
+          :${teamName(latestLogEntry.team)}_circle:
+          The ${teamName(latestLogEntry.team)} team rolled a ${latestLogEntry.roll}
+          and their turn was automatically passed.
+        `
+      : null
+
   const readme = ejs.render(template, {
     actions,
     state,
@@ -171,6 +181,7 @@ export async function generateReadme(
     context,
     teamTable,
     previousGames,
+    skipNotice,
   })
 
   const currentReadmeFile = await octokit.repos.getContents({


### PR DESCRIPTION
Show which team rolled and was skipped on the profile README so players do not need to expand the game log. Fixes #1293.