### PR TITLE
Show last turn(s) on main screen (#1418)

### DIFF
--- a/src/README.ejs
+++ b/src/README.ejs
@@ -17,6 +17,17 @@ You're on a team! :wave:
   <img src="https://raw.githubusercontent.com/<%- context.repo.owner %>/<%- context.repo.repo %>/play/games/current/board.<%- logItems[logItems.length - 1].issue %>.svg">
 </p>
 
+<% if (recentLogItems.length > 0) { -%>
+**Recent turns:**
+
+| Time | Turn | Event |
+| :---: | :---: | :--- |
+<% recentLogItems.forEach((logItem, index) => { -%>
+| <%- logItem.date %> | <%- logItems.length - recentLogItems.length + index %> | <%- logItem.description %> |
+<% }) -%>
+
+<% } -%>
+
 <% if (state.currentPlayer) { -%>
 **<%- state.currentPlayer === "b" ? ":black_circle:Black" : ":white_circle:White" %> team:** You rolled a <%- state.diceResult %>!
 <% } -%>

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -164,10 +164,14 @@ export async function generateReadme(
 
   const previousGames = await listPreviousGames(gamePath, octokit, context)
 
+  // Prepare recent log items for display on main screen (last 3 turns, excluding the current turn being displayed)
+  const recentLogItems = logItems.slice(-4, -1).reverse()
+
   const readme = ejs.render(template, {
     actions,
     state,
     logItems,
+    recentLogItems,
     context,
     teamTable,
     previousGames,


### PR DESCRIPTION
This PR adds a "Recent turns" section to the main screen of the game README, displaying the last 1-3 turns that have been played. This provides better context for players by showing recent game history without needing to expand the full game log.