### PR TITLE
Fix/auto move single option

### DIFF
--- a/src/README.ejs
+++ b/src/README.ejs
@@ -17,6 +17,10 @@ You're on a team! :wave:
   <img src="https://raw.githubusercontent.com/<%- context.repo.owner %>/<%- context.repo.repo %>/play/games/current/board.<%- logItems[logItems.length - 1].issue %>.svg">
 </p>
 
+<% if (skipNotice) { -%>
+<p align="center"><b><%- skipNotice %></b></p>
+<% } -%>
+
 <% if (state.currentPlayer) { -%>
 **<%- state.currentPlayer === "b" ? ":black_circle:Black" : ":white_circle:White" %> team:** You rolled a <%- state.diceResult %>!
 <% } -%>

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -164,6 +164,16 @@ export async function generateReadme(
 
   const previousGames = await listPreviousGames(gamePath, octokit, context)
 
+  const latestLogEntry = log.internalLog[log.internalLog.length - 1]
+  const skipNotice =
+    latestLogEntry?.action === "pass"
+      ? compress`
+          :${teamName(latestLogEntry.team)}_circle:
+          The ${teamName(latestLogEntry.team)} team rolled a ${latestLogEntry.roll}
+          and their turn was automatically passed.
+        `
+      : null
+
   const readme = ejs.render(template, {
     actions,
     state,
@@ -171,6 +181,7 @@ export async function generateReadme(
     context,
     teamTable,
     previousGames,
+    skipNotice,
   })
 
   const currentReadmeFile = await octokit.repos.getContents({

--- a/src/move.ts
+++ b/src/move.ts
@@ -202,6 +202,37 @@ export async function makeMove(
     changes = changes.concat(
       await makeMove(newState, "pass", gamePath, octokit, context, log),
     )
+  } else if (
+    !events?.gameWon &&
+    Object.keys(newState.possibleMoves!).length === 1
+  ) {
+    // If there is exactly 1 possible move, auto-execute it (#1123)
+    const onlyMoveKey = Object.keys(newState.possibleMoves!)[0]
+    const onlyFromPosition = parseInt(onlyMoveKey)
+    const onlyToPosition = newState.possibleMoves![onlyMoveKey]
+    
+    // Add a log entry for the auto-move
+    const autoEvents = analyseMove(newState, onlyFromPosition, onlyToPosition)
+    log.addToLog(
+      "move",
+      newState.currentPlayer!,
+      newState.diceResult ?? null,
+      onlyFromPosition,
+      onlyToPosition,
+      autoEvents,
+    )
+    
+    // Execute the auto-move
+    const autoState = Ur.takeTurn(newState, newState.currentPlayer!, onlyFromPosition)
+    
+    // Update README and state with the auto-moved state
+    changes = changes.concat(
+      await generateReadme(autoState, gamePath, octokit, context, log),
+    )
+    changes.push({
+      path: `${gamePath}/state.json`,
+      content: JSON.stringify(autoState, null, 2),
+    })
   } else {
     // Update README.md with the new state
     changes = changes.concat(


### PR DESCRIPTION
This PR adds automatic move execution when there is exactly 1 valid move available. When a player makes a move that results in the next player having only one possible move, that move is automatically executed without requiring manual intervention.