### PR TITLE
Fix/rate limiting

### DIFF
--- a/src/README.ejs
+++ b/src/README.ejs
@@ -17,6 +17,10 @@ You're on a team! :wave:
   <img src="https://raw.githubusercontent.com/<%- context.repo.owner %>/<%- context.repo.repo %>/play/games/current/board.<%- logItems[logItems.length - 1].issue %>.svg">
 </p>
 
+<% if (skipNotice) { -%>
+<p align="center"><b><%- skipNotice %></b></p>
+<% } -%>
+
 <% if (state.currentPlayer) { -%>
 **<%- state.currentPlayer === "b" ? ":black_circle:Black" : ":white_circle:White" %> team:** You rolled a <%- state.diceResult %>!
 <% } -%>

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -12,6 +12,9 @@ import { Log } from "@/log"
 import { getOppositeTeam, makeTeamListTable, teamName } from "@/teams"
 import { listPreviousGames } from "@/victory"
 
+// Cache for the EJS template to avoid repeated API calls
+let cachedTemplate: string | null = null
+
 export async function generateReadme(
   state: Ur.State,
   gamePath: string,
@@ -43,19 +46,22 @@ export async function generateReadme(
     ),
   )
 
-  // Grab the EJS template
-  const readmeFile = await octokit.repos.getContents({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    ref: "source",
-    path: "src/README.ejs",
-    mediaType: { format: "raw" },
-  })
-  // If a file was queried then data is not an array
-  if (Array.isArray(readmeFile.data)) {
-    throw new Error("FILE_IS_DIR")
+  // Grab the EJS template (cached to reduce API calls for rate limiting #1271)
+  if (!cachedTemplate) {
+    const readmeFile = await octokit.repos.getContents({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: "source",
+      path: "src/README.ejs",
+      mediaType: { format: "raw" },
+    })
+    // If a file was queried then data is not an array
+    if (Array.isArray(readmeFile.data)) {
+      throw new Error("FILE_IS_DIR")
+    }
+    cachedTemplate = Buffer.from(readmeFile.data.content!, "base64").toString()
   }
-  const template = Buffer.from(readmeFile.data.content!, "base64").toString()
+  const template = cachedTemplate
 
   // Make a list of possible actions that can be taken this turn, structured
   // into an array of links

--- a/src/generateReadme.ts
+++ b/src/generateReadme.ts
@@ -164,6 +164,16 @@ export async function generateReadme(
 
   const previousGames = await listPreviousGames(gamePath, octokit, context)
 
+  const latestLogEntry = log.internalLog[log.internalLog.length - 1]
+  const skipNotice =
+    latestLogEntry?.action === "pass"
+      ? compress`
+          :${teamName(latestLogEntry.team)}_circle:
+          The ${teamName(latestLogEntry.team)} team rolled a ${latestLogEntry.roll}
+          and their turn was automatically passed.
+        `
+      : null
+
   const readme = ejs.render(template, {
     actions,
     state,
@@ -171,6 +181,7 @@ export async function generateReadme(
     context,
     teamTable,
     previousGames,
+    skipNotice,
   })
 
   const currentReadmeFile = await octokit.repos.getContents({

--- a/src/move.ts
+++ b/src/move.ts
@@ -202,6 +202,37 @@ export async function makeMove(
     changes = changes.concat(
       await makeMove(newState, "pass", gamePath, octokit, context, log),
     )
+  } else if (
+    !events?.gameWon &&
+    Object.keys(newState.possibleMoves!).length === 1
+  ) {
+    // If there is exactly 1 possible move, auto-execute it (#1123)
+    const onlyMoveKey = Object.keys(newState.possibleMoves!)[0]
+    const onlyFromPosition = parseInt(onlyMoveKey)
+    const onlyToPosition = newState.possibleMoves![onlyMoveKey]
+    
+    // Add a log entry for the auto-move
+    const autoEvents = analyseMove(newState, onlyFromPosition, onlyToPosition)
+    log.addToLog(
+      "move",
+      newState.currentPlayer!,
+      newState.diceResult ?? null,
+      onlyFromPosition,
+      onlyToPosition,
+      autoEvents,
+    )
+    
+    // Execute the auto-move
+    const autoState = Ur.takeTurn(newState, newState.currentPlayer!, onlyFromPosition)
+    
+    // Update README and state with the auto-moved state
+    changes = changes.concat(
+      await generateReadme(autoState, gamePath, octokit, context, log),
+    )
+    changes.push({
+      path: `${gamePath}/state.json`,
+      content: JSON.stringify(autoState, null, 2),
+    })
   } else {
     // Update README.md with the new state
     changes = changes.concat(

--- a/src/updateSvg.ts
+++ b/src/updateSvg.ts
@@ -6,6 +6,9 @@ import { range } from "lodash"
 import { Change } from "@/play"
 import { getFile } from "@/getFile"
 
+// Cache for the SVG template to avoid repeated API calls
+let cachedSvgTemplate: string | null = null
+
 export async function updateSvg(
   state: State,
   gamePath: string,
@@ -42,20 +45,22 @@ export async function updateSvg(
     })
   }
 
-  // Get the contents of the template SVG
-  const svgFile = await octokit.repos.getContents({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    ref: "source", // TODO use compiled branch
-    path: baseSvgPath,
-    mediaType: { format: "raw" },
-  })
-  // If a file was queried then data is not an array
-  if (Array.isArray(svgFile.data)) {
-    throw new Error("FILE_IS_DIR")
+  // Get the contents of the template SVG (cached to reduce API calls for rate limiting #1271)
+  if (!cachedSvgTemplate) {
+    const svgFile = await octokit.repos.getContents({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: "source", // TODO use compiled branch
+      path: baseSvgPath,
+      mediaType: { format: "raw" },
+    })
+    // If a file was queried then data is not an array
+    if (Array.isArray(svgFile.data)) {
+      throw new Error("FILE_IS_DIR")
+    }
+    cachedSvgTemplate = Buffer.from(svgFile.data.content!, "base64").toString()
   }
-
-  let svg = Buffer.from(svgFile.data.content!, "base64").toString()
+  let svg = cachedSvgTemplate
 
   // Hide elements that should not be visible for this board
   // Tokens: tileN-T and tile0-TN, tile15-TN


### PR DESCRIPTION
This PR addresses API rate limiting issues by caching the EJS and SVG templates in memory. Previously, these templates were fetched from GitHub on every move, contributing to excessive API usage that caused rate limiting after ~40 moves per hour.
